### PR TITLE
Autovisit inherited methods

### DIFF
--- a/lib/screengem/automatic_visit.rb
+++ b/lib/screengem/automatic_visit.rb
@@ -36,7 +36,7 @@ module Screengem
     end
 
     def methods_to_decorate
-      @methods_to_decorate ||= screen_element.public_methods(false) - [:visit, :visit_path]
+      @methods_to_decorate ||= screen_element.public_methods(true) - [:visit, :visit_path]
     end
   end
 end

--- a/spec/screengem/automatic_visit_spec.rb
+++ b/spec/screengem/automatic_visit_spec.rb
@@ -2,7 +2,14 @@ module Screengem
   RSpec.describe AutomaticVisit do
     let(:capybara_session) { instance_double(Capybara::Session) }
 
-    let(:screen_element) do
+    let(:some_module) do
+      Module.new do
+        def an_inherited_method
+        end
+      end
+    end
+
+    let(:screen_element_class) do
       Class.new(Screengem::ScreenElement) do
         def visit_path
           "some/path"
@@ -15,8 +22,10 @@ module Screengem
 
         def a_private_method
         end
-      end.new
+      end.include(some_module)
     end
+
+    let(:screen_element) { screen_element_class.new }
 
     before do
       allow(screen_element).to receive(:page).and_return(capybara_session)
@@ -28,6 +37,14 @@ module Screengem
       expect(screen_element).to receive(:visit).and_call_original
 
       AutomaticVisit.new(screen_element).a_public_method
+    end
+
+    it "decorates an inherited method" do
+      allow(capybara_session).to receive(:current_path).and_return("some/path")
+
+      expect(screen_element).to receive(:visit).and_call_original
+
+      AutomaticVisit.new(screen_element).an_inherited_method
     end
 
     it "responds to a public method" do


### PR DESCRIPTION
This change enables the auto-visiting of inherited methods. Our codebase (Requirements Planning) has extracted some common code from our screen elements in a module, and those are not being auto-visited like the regular public API.

Feel free to reject the PR if this does not fit with the vision of the project.

Thanks!